### PR TITLE
Provide reproducible software environment deployment with GNU Guix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build
+on: [ push ]
+jobs:
+  build:
+    name: Run the pipeline
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Guix cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/guix
+          # use a key that (almost) never matches
+          key: guix-cache-${{ github.sha }}
+          restore-keys: |
+            guix-cache-
+      - name: Install Guix
+        uses: PromyLOPh/guix-install-action@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Instantiate specific Guix revision
+        run: guix time-machine -C sources/channels.scm -- describe
+      - name: Check
+        run: guix time-machine -C sources/channels.scm -- describe
+      - name: Build environment
+        working-directory: sources
+        run: guix time-machine -C channels.scm -- shell -C -m manifest.scm -- python3 --version
+      - name: Rebuild environment for checking
+        working-directory: sources
+        run: guix time-machine -C channels.scm -- shell -C -m manifest.scm -- python3 --version

--- a/GEERTS-reproduction/README.md
+++ b/GEERTS-reproduction/README.md
@@ -32,8 +32,23 @@ These additional modifications were:
 
 ## Installation
 
-Install the project by cloning it on your computer or by downloading a compressed version.</br>
-Install the required packages using the environment.yml file and the 'conda env create -f environment.yml', followed by the 'conda activate geerts_reproduction' command.
+Using [GNU Guix](https://guix.gnu.org), set up the complete software
+environment with:
+
+```
+$ guix time-machine -C channels.scm         \
+       -- shell -m manifest.scm --container \
+       --expose=../images=$HOME/path/to/local/clone/images
+```
+
+The `channels.scm` file instructs how to [replicate the exact Guix revision
+used for
+testing](https://guix.gnu.org/manual/en/html_node/Replicating-Guix.html),
+while `manifest.scm` defines [the software
+environment](https://guix.gnu.org/manual/en/html_node/Writing-Manifests.html)
+of this computational experiment.
+
+Alternatively, if you are not using Guix, install the required packages using the environment.yml file and the 'conda env create -f environment.yml', followed by the 'conda activate geerts_reproduction' command.
 You can also install the required packages using the requirements.txt file and the 'pip install -r requirements.txt' command
 
 ## Usage

--- a/GEERTS-reproduction/channels.scm
+++ b/GEERTS-reproduction/channels.scm
@@ -1,0 +1,11 @@
+(list (channel
+        (name 'guix)
+        (url "https://git.savannah.gnu.org/git/guix.git")
+        (branch "master")
+        (commit
+          "14c03807ba4bc81d42cf869f5b827f7da54ff843")
+        (introduction
+          (make-channel-introduction
+            "9edb3f66fd807b096b48283debdcddccfea34bad"
+            (openpgp-fingerprint
+              "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA")))))

--- a/GEERTS-reproduction/manifest.scm
+++ b/GEERTS-reproduction/manifest.scm
@@ -1,0 +1,15 @@
+(specifications->manifest
+ (list
+  "python"
+  "python-cython"
+  "python-matplotlib"
+  "python-networkx"
+  "python-numpy"
+  "python-pandas"
+  "python-scipy"
+  "python-seaborn"
+  "python-statsmodels"
+  "python-tqdm"
+
+  "gcc-toolchain@11"
+  ))

--- a/README.md
+++ b/README.md
@@ -26,9 +26,23 @@ Take note that the grid-search process require thousands of datapoints (we used 
 
 ## Installation
 
-Install the project by cloning it on your computer or by downloading a compressed version.</br>
-Install the required packages using the environment.yml file and the 'conda env create -f environment.yml', followed by the 'conda activate mixedcoord' command.
-You can also install the required packages using the requirements.txt file and the 'pip install -r requirements.txt' command
+Using [GNU Guix](https://guix.gnu.org), set up the complete software
+environment with:
+
+```
+$ guix time-machine -C channels.scm \
+       -- shell -m manifest.scm --pure
+```
+
+The `channels.scm` file instructs how to [replicate the exact Guix revision
+used for
+testing](https://guix.gnu.org/manual/en/html_node/Replicating-Guix.html),
+while `manifest.scm` defines [the software
+environment](https://guix.gnu.org/manual/en/html_node/Writing-Manifests.html)
+of this computational experiment.
+
+Alternatively, if you are not using Guix, install the required packages using the `environment.yml` file and the `conda env create -f environment.yml`, followed by the `conda activate mixedcoord` command.
+You can also install the required packages using the `requirements.txt` file and the `pip install -r requirements.txt` command.
 
 ## Usage
 

--- a/sources/channels.scm
+++ b/sources/channels.scm
@@ -1,0 +1,11 @@
+(list (channel
+        (name 'guix)
+        (url "https://git.savannah.gnu.org/git/guix.git")
+        (branch "master")
+        (commit
+          "14c03807ba4bc81d42cf869f5b827f7da54ff843")
+        (introduction
+          (make-channel-introduction
+            "9edb3f66fd807b096b48283debdcddccfea34bad"
+            (openpgp-fingerprint
+              "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA")))))

--- a/sources/manifest.scm
+++ b/sources/manifest.scm
@@ -1,0 +1,14 @@
+(specifications->manifest
+ (list
+  "python"
+  "python-ipython"
+  "python-matplotlib"
+  "python-numpy"
+  "python-pandas"
+  "python-patsy"
+  "python-scikit-image"
+  "python-scikit-learn"
+  "python-scipy"
+  "python-seaborn"
+  "python-statsmodels"
+  ))


### PR DESCRIPTION
Hi

As part of a [Reproducible Research hackathon](https://hpc.guix.info/blog/2023/05/reproducible-research-hackathon-let-redo/), we're looking into taking advantage of [Guix](https://guix.gnu.org) to support reproducible deployment for submissions to [ReScience C](https://rescience.github.io/bibliography/Misiek_2022.html).
 
This pulls requests **adds two files** (four indeed, 2 for the main code and 2 for the directory `GEERTS-reproduction`) that let us deploy the software environment of this computational experiment in a reproducible fashion; these two files are the Guix configuration, somehow replacing the files `environment.yml` or `requirements.txt`.  I tested it on my local machine; all the packages are provided by Guix. I also **added a GitHub action** to build the software environment upon push. However, the computations are too long for being run there.

Well, I obtain some figures.  Since I am not an expert, I am not able to say if they look similar or not, neither if I run the code with the right parameters.

Hope that helps.

Cc: @rougier @khinsen

